### PR TITLE
Add cleanup for test CDM tables and connections

### DIFF
--- a/tests/testthat/test-plotMeasurementTimings.R
+++ b/tests/testthat/test-plotMeasurementTimings.R
@@ -2,6 +2,7 @@ test_that("test measurement timing", {
   skip_on_cran()
   cdm <- testMockCdm()
   cdm <- copyCdm(cdm)
+
   result <- summariseMeasurementUse(
     cdm = cdm,
     codes = list("test_codelist" = c(3001467L, 45875977L)))
@@ -41,4 +42,6 @@ test_that("test measurement timing", {
   expect_error(plotMeasurementTimings(result, colour = "h"))
   expect_error(plotMeasurementTimings(result, timeScale = "h"))
   expect_error(plotMeasurementTimings(result, plotType =  "h"))
+
+  dropCreatedTables(cdm = cdm)
 })

--- a/tests/testthat/test-plotMeasurementValueAsConcept.R
+++ b/tests/testthat/test-plotMeasurementValueAsConcept.R
@@ -17,4 +17,6 @@ test_that("plotMeasurementValueAsConcept works", {
   # Table types
   expect_no_error(x <- plotMeasurementValueAsConcept(result))
   expect_true(ggplot2::is_ggplot(x))
+
+  dropCreatedTables(cdm = cdm)
 })

--- a/tests/testthat/test-plotMeasurementValueAsNumeric.R
+++ b/tests/testthat/test-plotMeasurementValueAsNumeric.R
@@ -23,4 +23,6 @@ test_that("plotMeasurementValueAsNumeric works", {
   # Table types
   expect_no_error(x <- plotMeasurementValueAsNumeric(result))
   expect_true(ggplot2::is_ggplot(x))
+
+  dropCreatedTables(cdm = cdm)
 })

--- a/tests/testthat/test-summariseCohortMeasurementUse.R
+++ b/tests/testthat/test-summariseCohortMeasurementUse.R
@@ -2,6 +2,7 @@ test_that("summariseCohortMeasurementUse works", {
   skip_on_cran()
   cdm <- testMockCdm()
   cdm <- copyCdm(cdm)
+
   res <- summariseCohortMeasurementUse(codes = list("test" = 3001467L), cohort = cdm$my_cohort, timing = "any")
   expect_equal(
     omopgenerics::settings(res),
@@ -85,14 +86,15 @@ test_that("summariseCohortMeasurementUse works", {
     'percentage', 'percentage', 'percentage', 'percentage', 'percentage', 'percentage',
     'percentage', 'percentage')
   )
+
+  dropCreatedTables(cdm = cdm)
 })
 
 test_that("test timings with eunomia", {
   skip_on_cran()
-  skip_if(Sys.getenv("EUNOMIA_DATA_FOLDER") == "")
-  # without cohort
-  con <- DBI::dbConnect(duckdb::duckdb(), CDMConnector::eunomiaDir())
-  cdm <- CDMConnector::cdmFromCon(con, cdmName = "eunomia", cdmSchema = "main", writeSchema = "main")
+  cdm <- omock::mockCdmFromDataset(datasetName = "GiBleed", source = "local") |>
+    copyCdm()
+
   cohort <- CohortConstructor::conceptCohort(cdm = cdm, conceptSet = list("condition" = 40481087L), name = "cohort")
   res_any <- summariseCohortMeasurementUse(
     codes = list("bmi" = c(4024958L, 36304833L), "egfr" = c(1619025L, 1619026L, 3029829L, 3006322L)),
@@ -194,12 +196,15 @@ test_that("test timings with eunomia", {
       sort(),
     c("1", "100")
   )
+
+  dropCreatedTables(cdm = cdm)
 })
 
 test_that("summariseCohortMeasurementUse straifications work", {
   skip_on_cran()
   cdm <- testMockCdm()
   cdm <- copyCdm(cdm)
+
   res <- summariseCohortMeasurementUse(
     cohort = cdm$my_cohort,
     codes = list("test" = 3001467L, "test2" = 1L, "test3" = 45875977L),
@@ -262,12 +267,15 @@ test_that("summariseCohortMeasurementUse straifications work", {
       dplyr::pull("estimate_value"),
     c("0", "0")
   )
+
+  dropCreatedTables(cdm = cdm)
 })
 
 test_that("summariseMeasurementUse checks", {
   skip_on_cran()
   cdm <- testMockCdm()
   cdm <- copyCdm(cdm)
+
   res <- summariseCohortMeasurementUse(
     cohort = cdm$my_cohort,
     codes = list("test" = 3001467L, "test2" = 1L, "test3" = 45875977L),
@@ -300,4 +308,6 @@ test_that("summariseMeasurementUse checks", {
       checks = character()
     )
   )
+
+  dropCreatedTables(cdm = cdm)
 })

--- a/tests/testthat/test-summariseMeasurementUse.R
+++ b/tests/testthat/test-summariseMeasurementUse.R
@@ -2,6 +2,7 @@ test_that("summariseMeasurementUse works", {
   skip_on_cran()
   cdm <- testMockCdm()
   cdm <- copyCdm(cdm)
+
   res <- summariseMeasurementUse(
     cdm = cdm,
     codes = list("test" = 3001467L, "test2" = 1L, "test3" = 45875977L),
@@ -113,12 +114,15 @@ test_that("summariseMeasurementUse works", {
   # suppress
   resSup <- res |> omopgenerics::suppress(minCellCount = 68)
   expect_equal(resSup$estimate_value |> unique(), c("100", "-", "81", "0"))
+
+  dropCreatedTables(cdm = cdm)
 })
 
 test_that("summariseMeasurementUse straifications work", {
   skip_on_cran()
   cdm <- testMockCdm()
   cdm <- copyCdm(cdm)
+
   res <- summariseMeasurementUse(
     cdm = cdm,
     codes = list("test" = 3001467L, "test2" = 1L, "test3" = 45875977L),
@@ -176,6 +180,7 @@ test_that("summariseMeasurementUse straifications work", {
     c("0", "0")
   )
 
+  dropCreatedTables(cdm = cdm)
 })
 
 test_that("summariseMeasurementUse expected fails", {
@@ -223,12 +228,15 @@ test_that("summariseMeasurementUse expected fails", {
     ageGroup = NULL,
     checks = "measurement_records"
   ))
+
+  dropCreatedTables(cdm = cdm)
 })
 
 test_that("summariseMeasurementUse checks", {
   skip_on_cran()
   cdm <- testMockCdm()
   cdm <- copyCdm(cdm)
+
   res <- summariseMeasurementUse(
     cdm = cdm,
     codes = list("test" = 3001467L, "test2" = 1L, "test3" = 45875977L),
@@ -264,12 +272,15 @@ test_that("summariseMeasurementUse checks", {
       checks = character()
     )
   )
+
+  dropCreatedTables(cdm = cdm)
 })
 
 test_that("summariseMeasurementUse observation domain", {
   skip_on_cran()
   cdm <- testMockCdm()
   cdm <- copyCdm(cdm)
+
   res <- summariseMeasurementUse(
     cdm = cdm,
     codes = list("mix" = c(3001467, 45875977, 194152, 4092121, 1033535)),
@@ -288,5 +299,6 @@ test_that("summariseMeasurementUse observation domain", {
     tab$domain_id |> sort(),
     c("Measurement", "Observation", "overall")
   )
-})
 
+  dropCreatedTables(cdm = cdm)
+})

--- a/tests/testthat/test-tableMeasurementTimings.R
+++ b/tests/testthat/test-tableMeasurementTimings.R
@@ -52,5 +52,5 @@ test_that("check that it works ", {
       '[header_name]Sex\n[header_level]overall', '[header_name]Sex\n[header_level]Male') %in%
       colnames(x$`_data`)))
 
-  CDMConnector::cdmDisconnect(cdm = cdm)
+  dropCreatedTables(cdm = cdm)
 })

--- a/tests/testthat/test-tableMeasurementValueAsConcept.R
+++ b/tests/testthat/test-tableMeasurementValueAsConcept.R
@@ -51,5 +51,5 @@ test_that("table works", {
   result <- result |> dplyr::filter(variable_name != "number records")
   expect_no_error(x <- tableMeasurementValueAsConcept(result, settingsColumn = "timing"))
 
-  CDMConnector::cdmDisconnect(cdm = cdm)
+  dropCreatedTables(cdm = cdm)
 })

--- a/tests/testthat/test-tableMeasurementValueAsNumeric.R
+++ b/tests/testthat/test-tableMeasurementValueAsNumeric.R
@@ -51,5 +51,5 @@ test_that("table works", {
   result <- result |> dplyr::filter(variable_name != "number records")
   expect_no_error(x <- tableMeasurementValueAsNumeric(result, settingsColumn = "timing"))
 
-  CDMConnector::cdmDisconnect(cdm = cdm)
+  dropCreatedTables(cdm = cdm)
 })


### PR DESCRIPTION
Introduces the dropCreatedTables() helper to clean up test-created tables and disconnect CDM connections after each test. Updates all relevant test files to use this function, improving test isolation and resource management.

fix #97 